### PR TITLE
fix: allow required tools for code-review CI

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -33,6 +33,7 @@ jobs:
         timeout-minutes: 15
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash,Read,Glob,Grep,Agent,Write,Skill"'
           prompt: |
             First, install the freefsm plugin:
             ```bash


### PR DESCRIPTION
## Summary

Add `--allowedTools` to claude-code-action so the FSM workflow can use Bash, Read, Glob, Grep, Agent, Write, and Skill tools. Without this, Claude gets 8 permission denials and produces no review comments.

## Test plan

- [ ] Merge and verify next PR gets review comments