### PR TITLE
ci: use OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -24,9 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public --provenance
       - name: Create GitHub Release
         run: gh release create "${{ github.ref_name }}" --generate-notes
         env:


### PR DESCRIPTION
## Summary
- Replace NPM_TOKEN with OIDC trusted publishing
- Add `id-token: write` permission and `--provenance` flag
- No more token rotation needed