### PR TITLE
fix: update npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: freefsm/package-lock.json
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
- Add `npm install -g npm@latest` before publish to ensure npm >= 11.5.1 for OIDC support
- Fixes E404 on `npm publish --provenance` with trusted publishing