### PR TITLE
fix: revert to NPM_TOKEN for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   publish:
@@ -25,7 +24,9 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - run: npm publish --access public --provenance
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create GitHub Release
         run: gh release create "${{ github.ref_name }}" --generate-notes
         env:


### PR DESCRIPTION
Revert OIDC trusted publishing — E404 on publish. Fall back to NPM_TOKEN.