### PR TITLE
fix: upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: freefsm/package-lock.json
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.11.1
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
Add npm install -g npm@latest — OIDC requires npm >= 11.5.1, Node 22 ships older.