### PR TITLE
ci: skip code review for draft PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -2,14 +2,15 @@ name: Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 
 jobs:
   review:
     if: >-
-      (github.event_name == 'pull_request' && github.event.action == 'opened'
+      (github.event_name == 'pull_request'
+       && !github.event.pull_request.draft
        && github.event.pull_request.head.repo.full_name == github.repository)
       || (github.event_name == 'issue_comment' && github.event.action == 'created'
           && github.event.issue.pull_request


### PR DESCRIPTION
## Summary

- Skip code review workflow for draft PRs by adding `!github.event.pull_request.draft` guard
- Add `ready_for_review` event type so review triggers when a draft is converted to ready
- `/bot-review` comment trigger remains unchanged as a manual override

## Test plan

E2E tested on freematters/testbed:
- [x] Draft PR opened → workflow **skipped**
- [x] Non-draft PR opened → workflow **triggered**
- [x] Draft PR converted to ready → workflow **triggered**