### PR TITLE
refactor: move reinstall script into freeflow package

### DIFF
--- a/packages/freeflow/scripts/reinstall.sh
+++ b/packages/freeflow/scripts/reinstall.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Build and install CLI globally
+npm run build
+npm install -g .
+
+# Register as Claude plugin
+fflow install claude

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cd "$(dirname "$0")/../freefsm"
-
-npm run build
-npm install -g .


### PR DESCRIPTION
## Summary
- Move `scripts/reinstall.sh` → `packages/freeflow/scripts/reinstall.sh` to co-locate with the package it builds
- Update path resolution (`cd` target) for new location
- Add `fflow install claude` step to auto-register the Claude plugin after install