### PR TITLE
fix(issue-bot): filter bot-posted comments in poll_issue.py

### DIFF
--- a/packages/freeflow/workflows/issue-bot/poll_issue.py
+++ b/packages/freeflow/workflows/issue-bot/poll_issue.py
@@ -114,8 +114,18 @@ def main() -> None:
 
             has_user_comment = False
             for comment in new_comments:
-                # Skip bot replies entirely
-                if comment["body"].startswith("[bot reply]"):
+                # Skip bot replies and bot-posted artifact comments
+                body = comment["body"]
+                if body.startswith("[bot reply]") or body.startswith("[from bot]"):
+                    continue
+                if body.startswith("## ") and body.split("\n", 1)[0].rstrip() in (
+                    "## requirements.md",
+                    "## design.md",
+                    "## plan.md",
+                    "## e2e.md",
+                    "## Checkpoint Summary",
+                    "## Spec Complete!",
+                ) or body.startswith("## research/"):
                     continue
 
                 # React with 👀 to user comments


### PR DESCRIPTION
## Summary

- Fix `poll_issue.py` picking up bot-posted comments as user replies, causing the workflow to fast-forward through approval steps
- Filter `[from bot]` prefixed comments (alongside existing `[bot reply]` filter)
- Filter artifact comments (`## design.md`, `## plan.md`, `## requirements.md`, `## e2e.md`, `## research/*`, `## Checkpoint Summary`, `## Spec Complete!`)

Root cause: the bot and user share the same GitHub account (`jamesrxian`), so the creator-only filter passes for bot comments too.

## Test plan

- [ ] Run issue-bot workflow, verify bot artifact comments are not picked up as user replies
- [ ] Verify real user replies (e.g., "1", "2", free text) are still detected correctly