### PR TITLE
refactor(workflows): add checkpoint to spec-gen, maximize reuse

### DIFF
--- a/packages/freeflow/workflows/github-spec-gen/workflow.yaml
+++ b/packages/freeflow/workflows/github-spec-gen/workflow.yaml
@@ -9,18 +9,14 @@
 #   create-issue
 #       |           \
 #   requirements ← → research
-#       |               |
-#       +-------+-------+
-#               |
-#          checkpoint
-#         /    |     \
-#   requirements  research  design
-#                           |     \
-#                          plan    requirements (gaps)
-#                         /    \
-#                   e2e-gen  design (revision)
-#                      |
-#                    done
+#       |
+#     design ← → requirements (gaps)
+#       |
+#      plan ← → design (revision)
+#       |
+#     e2e-gen
+#       |
+#     done
 #
 #   Fast forward: requirements → design → plan → e2e-gen → done (no intermediate approvals)
 
@@ -208,14 +204,11 @@ states:
       1. Post the structured requirements as a `## requirements.md` artifact comment.
       2. Update the issue body status checklist: check off "gathering requirements".
       3. Post transition options as an issue comment:
-         - "Requirements complete" (checkpoint)
-         - "Fast forward" (skip to design)
+         - "Revise requirements"
          - "Research first"
+         - "Proceed to design"
+         - "Fast forward" (skip to design, no intermediate approvals)
       4. Poll for the user's choice via comment reply.
-    transitions:
-      requirements complete: checkpoint
-      fast forward: design
-      need research: research
 
   research:
     from: "../spec-gen/workflow.yaml#research"
@@ -231,32 +224,9 @@ states:
       After completing research:
       1. Update the issue body status checklist: check off "research".
       2. Post transition options as an issue comment:
-         - "Research sufficient" (checkpoint)
          - "Back to requirements"
+         - "Proceed to design"
       3. Poll for the user's choice via comment reply.
-    transitions:
-      research sufficient: checkpoint
-      back to requirements: requirements
-
-  checkpoint:
-    from: "../spec-gen/workflow.yaml#checkpoint"
-    prompt: |
-      {{base}}
-
-      ### GitHub Adaptation
-
-      All artifact review happens via issue comments — do NOT read local files.
-      Fetch all comments on the issue to find artifacts:
-      ```bash
-      gh api 'repos/{owner}/{repo}/issues/{n}/comments' --paginate
-      ```
-
-      Identify artifact comments (those starting with `## requirements.md`, `## research/...`, etc.).
-      Post the summary as an issue comment.
-    transitions:
-      proceed to design: design
-      back to requirements: requirements
-      more research: research
 
   design:
     from: "../spec-gen/workflow.yaml#design"

--- a/packages/freeflow/workflows/spec-gen/workflow.yaml
+++ b/packages/freeflow/workflows/spec-gen/workflow.yaml
@@ -4,18 +4,14 @@
 #   create-structure
 #       |           \
 #   requirements ← → research
-#       |               |
-#       +-------+-------+
-#               |
-#          checkpoint
-#         /    |     \
-#   requirements  research  design
-#                           |     \
-#                          plan    requirements (gaps)
-#                         /    \
-#                   e2e-gen  design (revision)
-#                      |
-#                    done
+#       |
+#     design ← → requirements (gaps)
+#       |
+#      plan ← → design (revision)
+#       |
+#     e2e-gen (if design.md has E2E Testing section)
+#       |
+#     done
 #
 #   Fast forward: requirements → design → plan → e2e-gen → done (no intermediate approvals)
 
@@ -116,15 +112,17 @@ states:
 
       When you believe you have enough clarity on goals, constraints, and verification criteria,
       present a brief summary of what you've captured and ask the user:
-      - "Requirements complete" — review progress before design → checkpoint
-      - "Fast forward" — generate design, plan, and summary in one shot (no intermediate approvals) → design
+      - "Revise requirements" — revisit and refine what we have → requirements
       - "I need to research something first" → research
+      - "Proceed to design" → design
+      - "Fast forward" — generate design, plan, and summary in one shot (no intermediate approvals) → design
 
-      You MUST NOT move on until the user explicitly confirms requirements are complete.
+      You MUST NOT move on until the user explicitly confirms.
     transitions:
-      requirements complete: checkpoint
-      fast forward: design
+      revise requirements: requirements
       need research: research
+      proceed to design: design
+      fast forward: design
 
   research:
     prompt: |
@@ -154,42 +152,13 @@ states:
         available information, and ask the user for additional context. Do not block progress.
 
       When research is sufficient, ask the user:
-      - "Research sufficient" — review progress → checkpoint
       - "Back to requirements" — clarify requirements → requirements
+      - "Proceed to design" → design
 
       You MUST NOT proceed until the user confirms research is sufficient.
     transitions:
-      research sufficient: checkpoint
       back to requirements: requirements
-
-  checkpoint:
-    prompt: |
-      ## Iteration Checkpoint
-
-      Review all artifacts produced so far and assess readiness for design.
-
-      Process:
-      1. Read all existing artifacts (requirements.md, research/*.md).
-      2. Produce a structured summary covering:
-         - **Requirements**: Key decisions made and any open questions remaining
-         - **Research Findings**: Summary of each research topic investigated
-         - **Gaps & Contradictions**: Areas where requirements and research do not align, or
-           where more information is needed
-         - **Readiness Assessment**: Your assessment of whether there is enough information
-           to proceed to design
-
-      3. Present the summary to the user with transition options:
-         - Proceed to design → `proceed to design`
-         - Back to requirements → `back to requirements`
-         - More research → `more research`
-
-      4. Wait for the user's choice.
-
-      You MUST support iterating between requirements and research as many times as needed.
-    transitions:
       proceed to design: design
-      back to requirements: requirements
-      more research: research
 
   design:
     prompt: |


### PR DESCRIPTION
## Summary

- Add `checkpoint` state to spec-gen as an iteration review point between requirements/research and design
- Refactor github-spec-gen to reuse `requirements`, `research`, and `checkpoint` states via `from:` with GitHub adaptation overlays
- Both workflows now share identical transition graphs (except initial state name)

## Test plan

- [x] `fflow start` validates both workflow schemas successfully
- [x] All 154 vitest tests pass
- [x] Verified merged transitions match between both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Push round 1
- Fixed spec-gen research prompt to match transition key (`back to requirements`)
- Added explicit poll-for-choice instructions in github-spec-gen requirements/research adaptations
- Added explicit transitions block to github-spec-gen checkpoint state

## Push round 2
- Removed checkpoint state from both spec-gen and github-spec-gen per user feedback
- Requirements now offers: revise requirements, research, proceed to design, or fast forward
- Research now offers: back to requirements or proceed to design