### PR TITLE
perf(cli): lazy-import run and verify commands

### DIFF
--- a/packages/freeflow/src/cli.ts
+++ b/packages/freeflow/src/cli.ts
@@ -8,14 +8,12 @@ const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 import { Command } from "commander";
 import { current } from "./commands/current.js";
-import { verify } from "./commands/e2e/verify.js";
 import { finish } from "./commands/finish.js";
 import { goto } from "./commands/goto.js";
 import { history } from "./commands/history.js";
 import { install } from "./commands/install.js";
 import { list } from "./commands/list.js";
 import { convert } from "./commands/markdown/convert.js";
-import { run as runCmd } from "./commands/run.js";
 import { start } from "./commands/start.js";
 import { validate } from "./commands/validate.js";
 import { main as postToolUseMain } from "./hooks/post-tool-use.js";
@@ -93,6 +91,7 @@ program
   .option("--stay", "stay and accept user input after workflow completes")
   .action(async (_fsmPath: string, opts: Record<string, unknown>, cmd: Command) => {
     const { root, json } = getGlobalOpts(cmd);
+    const { run: runCmd } = await import("./commands/run.js");
     await runCmd({
       fsmPath: resolveWorkflowOrExit(_fsmPath, json ?? false),
       runId: opts.runId as string | undefined,
@@ -211,6 +210,7 @@ program
   .option("--verbose", "show tool calls in output")
   .action(async (planPath: string, opts: Record<string, unknown>, cmd: Command) => {
     const { root, json } = getGlobalOpts(cmd);
+    const { verify } = await import("./commands/e2e/verify.js");
     await verify({
       planPath: resolve(planPath),
       testDir: resolve(opts.testDir as string),


### PR DESCRIPTION
## Summary
- Move `run` and `verify` command imports from top-level static to dynamic `await import()` inside action handlers
- Avoids loading `@anthropic-ai/claude-agent-sdk`, `highlight.js`, and `marked` on every CLI invocation
- Reduces startup time from ~292ms to ~60ms for all non-run/verify commands (`goto`, `current`, `start`, etc.)

## Benchmark results

| | Before | After |
|---|---|---|
| `fflow --help` | 292 ms | 60 ms |
| `fflow goto` (5-state) | 301 ms | 65 ms |
| `fflow goto` (200-state, 1MB yaml) | 331 ms | 91 ms |

Profiled breakdown of the 292ms before:
- `highlight.js`: ~42ms (pulled in by `marked-terminal`, only used by `run`)
- `@anthropic-ai/claude-agent-sdk`: ~36ms (only used by `run` and `verify`)
- Node.js module compilation: ~36ms
- Other: ~178ms (Node.js bootstrap, commander, etc.)

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — all 213 tests pass
- [x] Verified `run` and `verify` commands still work (lazy import resolves correctly)