### PR TITLE
feat(workflows): add auto-research mode to spec-gen

### DIFF
--- a/packages/freeflow/workflows/github-spec-gen/workflow.yaml
+++ b/packages/freeflow/workflows/github-spec-gen/workflow.yaml
@@ -7,8 +7,9 @@
 # Flow:
 #
 #   create-issue
-#       |           \          \
-#   requirements ← → research   both (requirements + background research)
+#       |           \
+#   requirements ← → research
+#   (+ bg research if 'start with both')
 #       |
 #     design ← → requirements (gaps)
 #       |
@@ -258,16 +259,12 @@ states:
 
       ### Auto-Research Mode (GitHub)
 
-      If you arrived via "start with both", the base workflow dispatches a background
-      research agent. In addition to the base auto-research behavior:
-
-      When the background research agent completes:
-      1. Write each research topic to the local artifact cache
-         (`$ARTIFACTS/research/<topic>.md`)
-      2. Post each as a `## research/<topic>.md` artifact comment on the issue,
-         following the artifact creation guide
-      3. Save comment IDs to the tracking file
-      4. Update the issue body status checklist: check off "research"
+      In auto-research mode (see base workflow), the background research agent
+      follows the same process as the research state. When it completes
+      (`research/.done` exists), post the research artifacts to the issue —
+      same as the research state's GitHub Adaptation (write to local cache,
+      post as artifact comments, save comment IDs, check off "research" in
+      the status checklist).
 
       The brief summaries surfaced during Q&A are posted as part of the next
       Q&A comment — not as separate comments.

--- a/packages/freeflow/workflows/spec-gen/workflow.yaml
+++ b/packages/freeflow/workflows/spec-gen/workflow.yaml
@@ -2,8 +2,9 @@
 # Flow:
 #
 #   create-structure
-#       |           \          \
-#   requirements ← → research   both (requirements + background research)
+#       |           \
+#   requirements ← → research
+#   (+ bg research if 'start with both')
 #       |
 #     design ← → requirements (gaps)
 #       |
@@ -114,24 +115,29 @@ states:
 
       ### Auto-Research Mode
 
-      If you arrived via "start with both":
+      If `research/.auto-research` exists (written on first entry via "start with both"):
 
       1. Read rough-idea.md and auto-infer 2-4 research topics based on the idea's
          technical domain, dependencies, and areas of uncertainty.
       2. Dispatch a background Agent (using `run_in_background: true`) to investigate
-         all topics. The agent writes each topic to `research/<topic>.md` following the
-         standard research structure (Summary, Key Findings, Trade-offs, Recommendations,
-         References). Include Mermaid diagrams for architectures and data flows.
-      3. Begin the Q&A cycle immediately — do NOT wait for research to complete.
+         all topics. The agent follows the same process as the research state — writing
+         each topic to `research/<topic>.md` with the standard structure (Summary,
+         Key Findings, Trade-offs, Recommendations, References) and Mermaid diagrams.
+         The agent MUST write `research/.done` when all topics are complete.
+      3. Write the sentinel file `research/.auto-research` to mark auto-research mode.
+      4. Begin the Q&A cycle immediately — do NOT wait for research to complete.
+
+      On subsequent re-entries to this state, detect auto-research mode by checking
+      for the `research/.auto-research` file (do NOT rely on conversational memory).
 
       Between Q&A rounds (after recording the user's answer, before asking the next
-      question), check if the background research agent has completed. If it has:
+      question), check if `research/.done` exists. If it does:
       - Read the research files in `research/*.md`
       - Present a brief 2-3 line summary per topic to the user
       - Note that full findings are available in the research files
       - Factor the findings into your subsequent questions
 
-      If research has not completed yet, continue Q&A without blocking.
+      If `research/.done` does not exist yet, continue Q&A without blocking.
 
       When you believe you have enough clarity on goals, constraints, and verification criteria,
       present a brief summary of what you've captured and ask the user:


### PR DESCRIPTION
## Summary

- Adds a third option **"Requirements + auto-research"** to both `spec-gen` and `github-spec-gen` workflows
- When chosen, requirements Q&A starts immediately while a background agent auto-infers 2-4 research topics and investigates them
- Research results are surfaced as brief 2-3 line summaries at natural Q&A break points (between questions), without interrupting the flow
- In `github-spec-gen`, completed research is also posted as artifact comments on the issue and the "research" status checkbox is checked off

## Test plan

- [ ] Run `spec-gen` workflow, choose option 3 — verify research agent dispatched in background while Q&A proceeds
- [ ] Verify research summaries appear between Q&A rounds after background agent completes
- [ ] Run `github-spec-gen` workflow, choose option 3 — verify research artifacts posted as issue comments
- [ ] Verify existing options (1: requirements, 2: research) still work unchanged

## Push round 1
- Fixed flow diagrams in both workflows to annotate arrow instead of showing fake `both` state
- Added `research/.auto-research` sentinel file for reliable auto-research mode detection on re-entry
- Added `research/.done` sentinel for background agent completion detection
- Simplified github-spec-gen auto-research section to reference research state behavior per @bot request