### PR TITLE
feat(fflow): rename finish command to abort

### DIFF
--- a/packages/freeflow/AGENTS.md
+++ b/packages/freeflow/AGENTS.md
@@ -16,7 +16,7 @@ Read the design docs before making any changes.
 
 ```
 fflow CLI (human-readable default, -j JSON)
-    ├── commands/ (start, current, goto, finish)
+    ├── commands/ (start, current, goto, abort)
     ├── commands/e2e/ (gen, verify)
     ├── e2e/ (agent-session, multi-turn-session, verifier-tools, dual-stream-logger, verify-runner, parser, path-enumerator)
     ├── hooks/ (PostToolUse reminder)
@@ -43,7 +43,7 @@ Design principles:
 | `src/commands/start.ts` | Initialize run, commit start event |
 | `src/commands/current.ts` | Read snapshot, resolve state card |
 | `src/commands/goto.ts` | Validate transition, commit goto event |
-| `src/commands/finish.ts` | Abort run, commit finish event |
+| `src/commands/abort.ts` | Abort run, commit abort event |
 | `src/hooks/post-tool-use.ts` | PostToolUse hook: auto-detect, counter, reminder |
 | `hooks/hooks.json` | Claude Code hook declarations |
 | `skills/fflow-author/SKILL.md` | /fflow-author — guided workflow YAML creation |
@@ -64,7 +64,7 @@ Design principles:
 fflow start <fsm_path> [--run-id <id>] [-j]
 fflow current --run-id <id> [-j]
 fflow goto <target> --run-id <id> --on <label> [-j]
-fflow finish --run-id <id> [-j]
+fflow abort --run-id <id> [-j]
 fflow verify <plan.md> --test-dir <path> [--model <model>] [--verbose] [-j]
 ```
 

--- a/packages/freeflow/docs/design.md
+++ b/packages/freeflow/docs/design.md
@@ -27,7 +27,7 @@ Code is deterministic but rigid, hard to extend, and bug-prone.
 | Transitions            | Hard constraint (CLI rejects illegal)    | `goto` validates against FSM definition before committing                  |
 | Hook reminder interval | Every 5 tool calls (PostToolUse)         | Fixed interval, configurable later                                         |
 | Terminal state         | Fixed as `done`                          | Must exist in schema; `goto done` completes the run                        |
-| Scope (v1)             | `start`, `current`, `goto`, `finish`     | No `todo`, `viz`, `log`, `compile`                                         |
+| Scope (v1)             | `start`, `current`, `goto`, `abort`      | No `todo`, `viz`, `log`, `compile`                                         |
 
 ## Architecture
 
@@ -39,7 +39,7 @@ Code is deterministic but rigid, hard to extend, and bug-prone.
 |  +-- fflow-author/    +-- hooks.json         |
 |  +-- fflow/                                  |
 |  +-- current/          PostToolUse:           |
-|  +-- finish/            - every 5 tool calls |
+|  +-- abort/             - every 5 tool calls |
 |                           inject state       |
 |                           reminder           |
 |                                              |
@@ -50,7 +50,7 @@ Code is deterministic but rigid, hard to extend, and bug-prone.
 |                          initial state       |
 |  fflow current         query current state   |
 |  fflow goto <state>    validate+transition   |
-|  fflow finish          abort run             |
+|  fflow abort           abort run             |
 |                                              |
 +----------------------------------------------+
 |              ~/.freeflow/                     |
@@ -72,17 +72,17 @@ Code is deterministic but rigid, hard to extend, and bug-prone.
 3. Agent works -> PostToolUse hook every 5 tool calls injects state reminder via `fflow current`
 4. Agent calls `fflow goto X --on "label"` -> CLI validates transition legality; if legal, writes event, outputs new state card
 5. Agent reaches `done` state -> run completes (`run_status=completed`)
-6. `/fflow:finish` -> aborts an active run (`run_status=aborted`)
+6. `/fflow:abort` -> aborts an active run (`run_status=aborted`)
 
 ## Run Lifecycle
 
 ```
 active -> completed   (goto done)
-active -> aborted     (finish)
+active -> aborted     (abort)
 completed/aborted     terminal, no further operations
 ```
 
-`finish` is abort-only. Normal completion is `goto done`.
+`abort` is abort-only. Normal completion is `goto done`.
 
 ## FSM YAML Schema
 
@@ -187,7 +187,7 @@ states:
 
 ### Write path
 
-For state-changing operations (`start`, `goto`, `finish`):
+For state-changing operations (`start`, `goto`, `abort`):
 
 1. Acquire per-run directory lock (`lock/`)
 2. Read `snapshot.json`
@@ -263,10 +263,10 @@ Transitions:
 - If target is `done`: sets `run_status=completed`, `completion_reason=done_auto`
 - Errors with available transitions if illegal (`INVALID_TRANSITION`)
 
-### `fflow finish --run-id <id> [-j]`
+### `fflow abort --run-id <id> [-j]`
 
 ```
-$ fflow finish --run-id a1b2c3
+$ fflow abort --run-id a1b2c3
 OK FSM aborted (run_id: a1b2c3)
 Final state: Execute
 ```
@@ -347,9 +347,9 @@ Start an FSM workflow run. Generates a descriptive slug as `run_id`, calls `fflo
 
 Show current FSM state. Calls `fflow current` and displays the state card.
 
-### `/fflow:finish`
+### `/fflow:abort`
 
-Abort the current FSM run. Calls `fflow finish` and displays the terminal summary.
+Abort the current FSM run. Calls `fflow abort` and displays the terminal summary.
 
 ### Skills design decisions
 
@@ -368,7 +368,7 @@ Abort the current FSM run. Calls `fflow finish` and displays the terminal summar
 │   │   └── SKILL.md
 │   ├── current/
 │   │   └── SKILL.md
-│   └── finish/
+│   └── abort/
 │       └── SKILL.md
 ├── hooks/
 │   └── hooks.json
@@ -380,7 +380,7 @@ Abort the current FSM run. Calls `fflow finish` and displays the terminal summar
 │   │   ├── start.ts
 │   │   ├── current.ts
 │   │   ├── goto.ts
-│   │   └── finish.ts
+│   │   └── abort.ts
 │   ├── hooks/
 │   │   └── post-tool-use.ts   # periodic reminder hook
 │   ├── fsm.ts                 # core FSM logic (load yaml, validate)

--- a/packages/freeflow/skills/fflow/SKILL.md
+++ b/packages/freeflow/skills/fflow/SKILL.md
@@ -30,7 +30,7 @@ Strip the mode flag from args before extracting PATH.
 If there is a remembered `run_id` from a previous `/fflow` in this conversation, run `fflow current --run-id <run_id>`. If the current state is **not** `done`, prompt the user:
 - "You have an active workflow `<run_id>` in state `<state>`. Abort it and start a new one?"
 - Options: "Abort and start new" / "Keep it, start new anyway"
-- If the user chooses to abort, run `fflow finish --run-id <run_id>` first.
+- If the user chooses to abort, run `fflow abort --run-id <run_id>` first.
 - If the state is `done` or the run doesn't exist, skip this step silently.
 
 ### 2. Generate a run ID

--- a/packages/freeflow/src/__tests__/hooks/post-tool-use.test.ts
+++ b/packages/freeflow/src/__tests__/hooks/post-tool-use.test.ts
@@ -80,16 +80,16 @@ describe("handlePostToolUse — auto-detect fflow start", () => {
   });
 });
 
-describe("handlePostToolUse — auto-detect fflow finish", () => {
-  test("unbinds session on fflow finish", () => {
+describe("handlePostToolUse — auto-detect fflow abort", () => {
+  test("unbinds session on fflow abort", () => {
     const root = freshRoot();
     enableHook(root);
-    const store = setupActiveRun(root, "finish-run", fsmPath, "test-session", "plan");
+    const store = setupActiveRun(root, "abort-run", fsmPath, "test-session", "plan");
 
     const input = makeInput({
       tool_name: "Bash",
       tool_input: {
-        command: `fflow finish --run-id finish-run --root ${root}`,
+        command: `fflow abort --run-id abort-run --root ${root}`,
       },
       tool_response: "Run aborted.",
     });

--- a/packages/freeflow/src/__tests__/integration.test.ts
+++ b/packages/freeflow/src/__tests__/integration.test.ts
@@ -198,14 +198,14 @@ describe.concurrent("CLI — goto command", () => {
   });
 });
 
-// ─── CLI — finish command ────────────────────────────────────────
+// ─── CLI — abort command ────────────────────────────────────────
 
-describe.concurrent("CLI — finish command", () => {
+describe.concurrent("CLI — abort command", () => {
   test("aborts active run, shows transition history", () => {
-    const id = uniqueRunId("finish-human");
+    const id = uniqueRunId("abort-human");
     runCli(`start ${fsmMulti} --run-id ${id}`, { root: defaultRoot() });
     runCli(`goto review --run-id ${id} --on ready`, { root: defaultRoot() });
-    const { stdout, exitCode } = runCli(`finish --run-id ${id}`, {
+    const { stdout, exitCode } = runCli(`abort --run-id ${id}`, {
       root: defaultRoot(),
     });
     expect(exitCode).toBe(0);
@@ -217,9 +217,9 @@ describe.concurrent("CLI — finish command", () => {
   });
 
   test("JSON output with completion_reason=manual_abort", () => {
-    const id = uniqueRunId("finish-json");
+    const id = uniqueRunId("abort-json");
     runCli(`start ${fsmMinimal} --run-id ${id}`, { root: defaultRoot() });
-    const { envelope, exitCode } = runCliJson(`finish --run-id ${id}`, {
+    const { envelope, exitCode } = runCliJson(`abort --run-id ${id}`, {
       root: defaultRoot(),
     });
     expect(exitCode).toBe(0);
@@ -232,10 +232,10 @@ describe.concurrent("CLI — finish command", () => {
   });
 
   test("RUN_NOT_ACTIVE error on already aborted run", () => {
-    const id = uniqueRunId("finish-double");
+    const id = uniqueRunId("abort-double");
     runCli(`start ${fsmMinimal} --run-id ${id}`, { root: defaultRoot() });
-    runCli(`finish --run-id ${id}`, { root: defaultRoot() });
-    const { envelope, exitCode } = runCliJson(`finish --run-id ${id}`, {
+    runCli(`abort --run-id ${id}`, { root: defaultRoot() });
+    const { envelope, exitCode } = runCliJson(`abort --run-id ${id}`, {
       root: defaultRoot(),
       expectFail: true,
     });

--- a/packages/freeflow/src/__tests__/markdown-mode.test.ts
+++ b/packages/freeflow/src/__tests__/markdown-mode.test.ts
@@ -82,12 +82,12 @@ describe("markdown mode", () => {
     expect(envelope.code).toBe("MARKDOWN_MODE");
   });
 
-  test("finish on markdown run → CliError MARKDOWN_MODE", () => {
-    const id = uniqueRunId("md-finish-block");
+  test("abort on markdown run → CliError MARKDOWN_MODE", () => {
+    const id = uniqueRunId("md-abort-block");
     const root = defaultRoot();
     runCli(`start ${fsmMinimal} --run-id ${id} --markdown`, { root });
 
-    const { envelope, exitCode } = runCliJson(`finish --run-id ${id}`, {
+    const { envelope, exitCode } = runCliJson(`abort --run-id ${id}`, {
       root,
       expectFail: true,
     });

--- a/packages/freeflow/src/__tests__/store.test.ts
+++ b/packages/freeflow/src/__tests__/store.test.ts
@@ -118,14 +118,14 @@ describe("Store — terminal states", () => {
     expect(snap?.run_status).toBe("completed");
   });
 
-  test("finish produces aborted snapshot", () => {
+  test("abort produces aborted snapshot", () => {
     const s = freshStore();
     s.initRun("abort", "/fake.yaml");
     s.commit("abort", startEvent("plan"), startSnapshot("plan"));
     const { snapshot } = s.commit(
       "abort",
       {
-        event: "finish",
+        event: "abort",
         from_state: "plan",
         to_state: null,
         on_label: null,
@@ -140,6 +140,33 @@ describe("Store — terminal states", () => {
 
     const snap = s.readSnapshot("abort");
     expect(snap?.run_status).toBe("aborted");
+  });
+
+  test("backward compat: reading finish events normalizes to abort", () => {
+    const s = freshStore();
+    s.initRun("compat-finish", "/fake.yaml");
+    s.commit("compat-finish", startEvent("plan"), startSnapshot("plan"));
+
+    // Manually write a "finish" event to the JSONL file (simulating old data)
+    const { appendFileSync } = require("node:fs");
+    const eventsPath = join(s.getRunDir("compat-finish"), "events.jsonl");
+    const finishEvent = JSON.stringify({
+      seq: 2,
+      ts: new Date().toISOString(),
+      run_id: "compat-finish",
+      event: "finish",
+      from_state: "plan",
+      to_state: null,
+      on_label: null,
+      actor: "human",
+      reason: "manual_abort",
+      metadata: null,
+    });
+    appendFileSync(eventsPath, `${finishEvent}\n`, "utf-8");
+
+    const events = s.readEvents("compat-finish");
+    expect(events).toHaveLength(2);
+    expect(events[1].event).toBe("abort");
   });
 });
 

--- a/packages/freeflow/src/__tests__/store.test.ts
+++ b/packages/freeflow/src/__tests__/store.test.ts
@@ -1,3 +1,4 @@
+import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { Store } from "../store.js";
@@ -148,7 +149,6 @@ describe("Store — terminal states", () => {
     s.commit("compat-finish", startEvent("plan"), startSnapshot("plan"));
 
     // Manually write a "finish" event to the JSONL file (simulating old data)
-    const { appendFileSync } = require("node:fs");
     const eventsPath = join(s.getRunDir("compat-finish"), "events.jsonl");
     const finishEvent = JSON.stringify({
       seq: 2,

--- a/packages/freeflow/src/cli.ts
+++ b/packages/freeflow/src/cli.ts
@@ -7,8 +7,8 @@ import { dirname, join, resolve } from "node:path";
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 import { Command } from "commander";
+import { abort } from "./commands/abort.js";
 import { current } from "./commands/current.js";
-import { finish } from "./commands/finish.js";
 import { goto } from "./commands/goto.js";
 import { history } from "./commands/history.js";
 import { install } from "./commands/install.js";
@@ -51,7 +51,7 @@ Example:
   $ fflow start workflow.yaml --run-id my-run
   $ fflow goto review --run-id my-run --on "draft ready"
   $ fflow current --run-id my-run
-  $ fflow finish --run-id my-run`,
+  $ fflow abort --run-id my-run`,
   )
   .version(version)
   .option("--root <path>", "storage root (default: ~/.freeflow/ or $FREEFLOW_ROOT)")
@@ -143,12 +143,12 @@ program
   });
 
 program
-  .command("finish")
+  .command("abort")
   .description("abort an active run")
   .requiredOption("--run-id <id>", "run identifier")
   .action((opts: Record<string, unknown>, cmd: Command) => {
     const { root, json } = getGlobalOpts(cmd);
-    finish({
+    abort({
       runId: opts.runId as string,
       root: resolveRoot(root),
       json: json ?? false,

--- a/packages/freeflow/src/commands/abort.ts
+++ b/packages/freeflow/src/commands/abort.ts
@@ -23,7 +23,7 @@ function computeRunStats(events: StoreEvent[]): RunStats {
       if (e.to_state && !statesVisited.includes(e.to_state)) {
         statesVisited.push(e.to_state);
       }
-    } else if (e.event === "finish") {
+    } else if (e.event === "abort" || e.event === ("finish" as string)) {
       parts.push("-[aborted]");
     }
   }
@@ -43,13 +43,13 @@ function computeRunStats(events: StoreEvent[]): RunStats {
   };
 }
 
-export interface FinishArgs {
+export interface AbortArgs {
   runId: string;
   root: string;
   json: boolean;
 }
 
-export function finish(args: FinishArgs): void {
+export function abort(args: AbortArgs): void {
   try {
     const store = new Store(args.root);
 
@@ -81,7 +81,7 @@ export function finish(args: FinishArgs): void {
       store.commit(
         args.runId,
         {
-          event: "finish",
+          event: "abort",
           from_state: snapshot.state,
           to_state: null,
           on_label: null,

--- a/packages/freeflow/src/commands/abort.ts
+++ b/packages/freeflow/src/commands/abort.ts
@@ -23,7 +23,7 @@ function computeRunStats(events: StoreEvent[]): RunStats {
       if (e.to_state && !statesVisited.includes(e.to_state)) {
         statesVisited.push(e.to_state);
       }
-    } else if (e.event === "abort" || e.event === ("finish" as string)) {
+    } else if (e.event === "abort") {
       parts.push("-[aborted]");
     }
   }

--- a/packages/freeflow/src/commands/history.ts
+++ b/packages/freeflow/src/commands/history.ts
@@ -76,7 +76,7 @@ function formatTimeline(summaries: TransitionSummary[]): string {
         target: s.to ?? "?",
         duration,
       });
-    } else if (s.event === "finish") {
+    } else if (s.event === "abort") {
       const duration =
         s.duration_ms !== null ? `(${formatDuration(s.duration_ms)})` : "";
       rows.push({ prefix, transition: "-- (aborted)", target: "", duration });

--- a/packages/freeflow/src/hooks/post-tool-use.ts
+++ b/packages/freeflow/src/hooks/post-tool-use.ts
@@ -12,7 +12,7 @@ export interface HookInput {
 }
 
 const START_RE = /(?:fflow|freefsm)\s+start\b/;
-const FINISH_RE = /(?:fflow|freefsm)\s+finish\b/;
+const ABORT_RE = /(?:fflow|freefsm)\s+abort\b/;
 const GOTO_DONE_RE = /(?:fflow|freefsm)\s+goto\s+done\b/;
 const RUN_ID_FLAG_RE = /--run-id\s+(\S+)/;
 
@@ -40,7 +40,7 @@ export function handlePostToolUse(input: HookInput, root: string): string | null
           store.updateMeta(runId, { session_id: sessionId });
         }
       }
-    } else if (FINISH_RE.test(cmd) || GOTO_DONE_RE.test(cmd)) {
+    } else if (ABORT_RE.test(cmd) || GOTO_DONE_RE.test(cmd)) {
       store.unbindSession(sessionId);
       return null;
     }

--- a/packages/freeflow/src/store.ts
+++ b/packages/freeflow/src/store.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 // --- Types ---
 
 export type RunStatus = "active" | "completed" | "aborted";
-export type EventType = "start" | "goto" | "finish";
+export type EventType = "start" | "goto" | "abort";
 export type Actor = "agent" | "human" | "system";
 
 export interface GatewayInfo {
@@ -225,7 +225,13 @@ export class Store {
     if (raw.length === 0) {
       return [];
     }
-    return raw.split("\n").map((line) => JSON.parse(line) as StoreEvent);
+    return raw.split("\n").map((line) => {
+      const ev = JSON.parse(line) as StoreEvent;
+      if ((ev.event as string) === "finish") {
+        ev.event = "abort";
+      }
+      return ev;
+    });
   }
 
   withLock<T>(runId: string, fn: () => T): T {

--- a/packages/freeflow/src/store.ts
+++ b/packages/freeflow/src/store.ts
@@ -227,8 +227,10 @@ export class Store {
     }
     return raw.split("\n").map((line) => {
       const ev = JSON.parse(line) as StoreEvent;
+      // Backward-compat: runs persisted before the finish→abort rename still have
+      // event:"finish" on disk. Normalize on read so all callers see "abort".
       if ((ev.event as string) === "finish") {
-        ev.event = "abort";
+        return { ...ev, event: "abort" as EventType };
       }
       return ev;
     });


### PR DESCRIPTION
## Summary
- Rename `fflow finish` CLI command to `fflow abort` to better reflect its purpose
- Rename internal `EventType` from `"finish"` to `"abort"` and source file `finish.ts` → `abort.ts`
- Add backward compatibility: `readEvents()` normalizes old `"finish"` events to `"abort"`
- Update hook regex, docs, skills, and all tests

## Test plan
- [x] All 233 existing tests pass (updated to use `abort`)
- [x] New backward compat test: old `"finish"` events in JSONL normalize to `"abort"` on read
- [x] Build passes, lint clean

## Push round 1
- Rebased onto latest main (picked up `--markdown` feature from #133)
- Fixed markdown-mode test: updated `finish` → `abort` in `markdown-mode.test.ts` to match the rename

## Push round 2
- Fixed in-place mutation in backward-compat event normalization (`store.ts`): return new object via spread instead of mutating parsed event
- Added explanatory comment for the normalization logic