### PR TITLE
docs: add Vercel monorepo deployment convention and CI compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
             for pkg in packages/*/; do
               pkg_name=$(basename "$pkg")
               if echo "$CHANGED" | grep -q "^packages/$pkg_name/"; then
-                PACKAGES="$PACKAGES -w packages/$pkg_name"
+                if jq -e '.scripts.test' "$pkg/package.json" > /dev/null 2>&1; then
+                  PACKAGES="$PACKAGES -w packages/$pkg_name"
+                else
+                  echo "Skipping packages/$pkg_name (no test script)"
+                fi
               fi
             done
             if [ -z "$PACKAGES" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .worktrees/
 docs/plans/
 specs/
+.vercel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,16 +32,22 @@ npm run check
 ```
 freematters/
 ├── packages/
-│   └── freeflow/        # Workflow runtime package
-│       ├── src/           # TypeScript source
-│       ├── skills/        # Claude Code / Codex skills
-│       ├── hooks/         # Claude Code hooks
-│       ├── workflows/     # Bundled workflow definitions
-│       └── docs/          # Design docs
+│   ├── freeflow/        # Workflow runtime package
+│   │   ├── src/           # TypeScript source
+│   │   ├── skills/        # Claude Code / Codex skills
+│   │   ├── hooks/         # Claude Code hooks
+│   │   ├── workflows/     # Bundled workflow definitions
+│   │   └── docs/          # Design docs
+│   └── codoc/             # Collaborative markdown editor
+├── docs/                  # Repo-level documentation
 ├── biome.json           # Shared lint/format config
 ├── tsconfig.base.json   # Shared TypeScript base config
 └── tsconfig.json        # Project references
 ```
+
+## Deployment
+
+Deployable packages each have their own `vercel.json` and a dedicated Vercel project with Root Directory pointing to the package path. See [docs/vercel-deploy.md](docs/vercel-deploy.md) for the full convention and how to add new deployable apps.
 
 ## Code Style
 

--- a/docs/vercel-deploy.md
+++ b/docs/vercel-deploy.md
@@ -1,0 +1,95 @@
+# Vercel Monorepo Deployment Convention
+
+Each deployable app in this monorepo gets its own Vercel project. This keeps configurations isolated — adding or changing one app never affects another.
+
+## How It Works
+
+1. Each deployable package has a `vercel.json` in its directory
+2. Each Vercel project's **Root Directory** points to the package path (e.g., `packages/my-app`)
+3. Vercel auto-detects npm workspaces and runs `npm install` from the repo root
+4. `ignoreCommand` ensures only changes within the package trigger a deployment
+
+## Adding a New Deployable App
+
+### 1. Create the package
+
+```bash
+mkdir -p packages/<app-name>/
+# Add package.json with build script, source files, etc.
+```
+
+### 2. Add `vercel.json` in the package directory
+
+Use the appropriate template below.
+
+### 3. Create a Vercel project
+
+1. Go to [vercel.com](https://vercel.com) → **Add New → Project**
+2. Import the `freematters/freematters` repo
+3. Set **Root Directory** to `packages/<app-name>`
+4. Set **Framework Preset** to match your app (or "Other" for static)
+5. Leave Build/Output overrides empty — `vercel.json` handles it
+6. Deploy
+
+### 4. Update root `package.json`
+
+Add the package to the root `build` script so CI also builds it.
+
+## `vercel.json` Templates
+
+### Static HTML
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "public",
+  "framework": null,
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
+}
+```
+
+### Next.js
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
+}
+```
+
+Next.js auto-detects build command and output directory.
+
+### Vite SPA
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet .",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}
+```
+
+The `rewrites` rule enables client-side routing.
+
+## Cross-Package Build Dependencies
+
+If your app depends on another workspace package at build time, chain the builds:
+
+```json
+{
+  "buildCommand": "npm run build -w packages/shared-lib && npm run build",
+  ...
+}
+```
+
+## Notes
+
+- **No root `vercel.json`** — each package owns its config
+- **No `.vercelignore`** — Root Directory scopes file uploads automatically
+- **First deployment**: `ignoreCommand` may fail on the very first commit (no `HEAD^`). Vercel defaults to building in this case, which is correct
+- **Install**: don't set `installCommand` unless you have a specific reason — Vercel's workspace auto-detection handles it


### PR DESCRIPTION
Add a per-package Vercel deployment pattern so new deployable apps can be added quickly without modifying root-level config. Each app owns its own vercel.json and gets a dedicated Vercel project with Root Directory pointing to its package path.

- Create docs/vercel-deploy.md with convention, templates (static/Next.js/Vite), and step-by-step guide
- Add .vercel to .gitignore
- Update CONTRIBUTING.md with codoc in project structure and deployment section
- Update ci.yml test job to skip packages without a test script