### PR TITLE
feat(freeflow): show sub-workflow guide only on first entry to its initial state

### DIFF
--- a/packages/freeflow/src/__tests__/commands/guide-gating.test.ts
+++ b/packages/freeflow/src/__tests__/commands/guide-gating.test.ts
@@ -1,0 +1,132 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { current } from "../../commands/current.js";
+import { goto } from "../../commands/goto.js";
+import { start } from "../../commands/start.js";
+import { type StateCard, formatSubagentDispatch } from "../../output.js";
+import { Store } from "../../store.js";
+import { cleanupTempDir, createTempDir, uniqueRunId } from "../fixtures.js";
+
+/**
+ * Workflow with a per-state guide on the initial state `a`, plus a second
+ * state `b` we can toggle to and back from.
+ */
+const PER_STATE_GUIDE_FSM = `
+version: 1
+guide: "Top-level guide"
+initial: a
+states:
+  a:
+    prompt: "Prompt A."
+    guide: "STATE-A-GUIDE"
+    transitions:
+      next: b
+      finish: done
+  b:
+    prompt: "Prompt B."
+    transitions:
+      back: a
+      finish: done
+  done:
+    prompt: "Done."
+    transitions: {}
+`;
+
+let tmp: string;
+
+afterEach(() => {
+  if (tmp) cleanupTempDir(tmp);
+});
+
+function captureStdout(fn: () => void): string {
+  const writes: string[] = [];
+  const origWrite = process.stdout.write;
+  process.stdout.write = ((str: string) => {
+    writes.push(str);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    fn();
+  } finally {
+    process.stdout.write = origWrite;
+  }
+  return writes.join("");
+}
+
+describe("state-card guide gating", () => {
+  test("T12: first-entry start includes guide and records shown_guides; subsequent current omits guide and leaves snapshot unchanged", () => {
+    tmp = createTempDir("gate-t12");
+    const fsmPath = join(tmp, "wf.yaml");
+    writeFileSync(fsmPath, PER_STATE_GUIDE_FSM, "utf-8");
+    const root = join(tmp, "root");
+    const runId = uniqueRunId("t12");
+
+    const startOut = captureStdout(() => {
+      start({ fsmPath, runId, root, json: false });
+    });
+    expect(startOut).toContain("STATE-A-GUIDE");
+
+    const store = new Store(root);
+    const snap1 = store.readSnapshot(runId);
+    expect(snap1).not.toBeNull();
+    expect(snap1?.shown_guides).toEqual(["a"]);
+    const last_seq1 = snap1?.last_seq;
+    const updated_at1 = snap1?.updated_at;
+
+    const currentOut = captureStdout(() => {
+      current({ runId, root, json: false });
+    });
+    expect(currentOut).not.toContain("STATE-A-GUIDE");
+
+    const snap2 = store.readSnapshot(runId);
+    expect(snap2?.shown_guides).toEqual(["a"]);
+    expect(snap2?.last_seq).toBe(last_seq1);
+    expect(snap2?.updated_at).toBe(updated_at1);
+  });
+
+  test("T13: revisiting the same state via goto does not re-show guide and does not duplicate shown_guides", () => {
+    tmp = createTempDir("gate-t13");
+    const fsmPath = join(tmp, "wf.yaml");
+    writeFileSync(fsmPath, PER_STATE_GUIDE_FSM, "utf-8");
+    const root = join(tmp, "root");
+    const runId = uniqueRunId("t13");
+
+    const startOut = captureStdout(() => {
+      start({ fsmPath, runId, root, json: false });
+    });
+    expect(startOut).toContain("STATE-A-GUIDE");
+
+    const store = new Store(root);
+    expect(store.readSnapshot(runId)?.shown_guides).toEqual(["a"]);
+
+    // Go to b
+    captureStdout(() => {
+      goto({ target: "b", runId, on: "next", root, json: false });
+    });
+    expect(store.readSnapshot(runId)?.shown_guides).toEqual(["a"]);
+
+    // Back to a — second visit should not re-show the guide
+    const backOut = captureStdout(() => {
+      goto({ target: "a", runId, on: "back", root, json: false });
+    });
+    expect(backOut).not.toContain("STATE-A-GUIDE");
+    expect(store.readSnapshot(runId)?.shown_guides).toEqual(["a"]);
+  });
+
+  test("subagent dispatch bypass: formatSubagentDispatch always includes per-state guide regardless of shown_guides", () => {
+    const card: StateCard = {
+      state: "work",
+      prompt: "Do the heavy lifting.",
+      todos: null,
+      transitions: { complete: "done" },
+      guide: "SUBAGENT-STATE-GUIDE",
+      subagent: true,
+    };
+
+    // Simulate the "already shown" case: caller has not stripped the guide
+    // because formatSubagentDispatch is the bypass path.
+    const out = formatSubagentDispatch(card, "run-xyz");
+    expect(out).toContain("SUBAGENT-STATE-GUIDE");
+  });
+});

--- a/packages/freeflow/src/__tests__/fsm-workflow-compose.test.ts
+++ b/packages/freeflow/src/__tests__/fsm-workflow-compose.test.ts
@@ -113,9 +113,10 @@ describe("workflow composition — basic expansion", () => {
     // Non-workflow state transitions rewritten to entry point
     expect(fsm.states.setup.transitions.ready).toBe("build/create");
 
-    // Child guide propagated to expanded states
+    // Child guide attached only to the expanded child initial state
     expect(fsm.states["build/create"].guide).toBe("Child guide for simple workflow.");
-    expect(fsm.states["build/done"].guide).toBe("Child guide for simple workflow.");
+    expect(fsm.states["build/review"].guide).toBeUndefined();
+    expect(fsm.states["build/done"].guide).toBeUndefined();
   });
 });
 
@@ -195,6 +196,22 @@ describe("workflow composition — guide scoping", () => {
     expect(fsm.states["sub/step"].guide).toContain("Base guide content.");
     expect(fsm.states["sub/step"].guide).toContain("Extra child rules for compose.");
     expect(fsm.states.done.guide).toBeUndefined();
+  });
+
+  test("T11: sub-workflow guide attached to child initial state only", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fflow-test-t11-"));
+    const childYaml =
+      'version: 1\nguide: "SUB GUIDE"\ninitial: inner_a\nstates:\n  inner_a:\n    prompt: "Inner A."\n    transitions:\n      next: done\n  done:\n    prompt: "Inner done."\n    transitions: {}\n';
+    writeFileSync(join(dir, "child.workflow.yaml"), childYaml);
+    const parentPath = join(dir, "parent.workflow.yaml");
+    writeFileSync(
+      parentPath,
+      "version: 1.2\ninitial: outer\nstates:\n  outer:\n    workflow: ./child.workflow.yaml\n    transitions:\n      completed: done\n  done:\n    prompt: d\n    transitions: {}\n",
+    );
+
+    const fsm = loadFsm(parentPath);
+    expect(fsm.states["outer/inner_a"].guide).toBe("SUB GUIDE");
+    expect(fsm.states["outer/done"].guide).toBeUndefined();
   });
 });
 

--- a/packages/freeflow/src/__tests__/store.test.ts
+++ b/packages/freeflow/src/__tests__/store.test.ts
@@ -1,4 +1,4 @@
-import { appendFileSync } from "node:fs";
+import { appendFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { Store } from "../store.js";
@@ -271,6 +271,62 @@ describe("Store — lite mode data models", () => {
 
     const meta = s.readMeta("no-lite");
     expect(meta.lite).toBeUndefined();
+  });
+});
+
+describe("Store — shown_guides", () => {
+  test("round-trip: writing shown_guides preserves the array verbatim", () => {
+    const s = freshStore();
+    s.initRun("shown-rt", "/fake.yaml");
+    s.commit("shown-rt", startEvent("plan"), {
+      run_status: "active",
+      state: "plan",
+      shown_guides: ["a", "b"],
+    });
+
+    const snap = s.readSnapshot("shown-rt");
+    expect(snap).not.toBeNull();
+    expect(snap?.shown_guides).toEqual(["a", "b"]);
+  });
+
+  test("backward-compat: snapshot JSON without shown_guides reads as undefined", () => {
+    const s = freshStore();
+    s.initRun("shown-compat", "/fake.yaml");
+    // Manually write a snapshot JSON without shown_guides (simulating older runs)
+    const snapshotPath = join(s.getRunDir("shown-compat"), "snapshot.json");
+    const legacySnapshot = {
+      run_id: "shown-compat",
+      run_status: "active",
+      state: "plan",
+      last_seq: 1,
+      updated_at: new Date().toISOString(),
+    };
+    writeFileSync(snapshotPath, JSON.stringify(legacySnapshot, null, 2), "utf-8");
+
+    const snap = s.readSnapshot("shown-compat");
+    expect(snap).not.toBeNull();
+    expect(snap?.shown_guides).toBeUndefined();
+    expect(snap?.state).toBe("plan");
+  });
+
+  test("append semantics: starting without shown_guides then adding an entry persists it", () => {
+    const s = freshStore();
+    s.initRun("shown-append", "/fake.yaml");
+    // First commit has no shown_guides
+    s.commit("shown-append", startEvent("plan"), startSnapshot("plan"));
+
+    const first = s.readSnapshot("shown-append");
+    expect(first?.shown_guides).toBeUndefined();
+
+    // Second commit adds one entry
+    s.commit("shown-append", gotoEvent("plan", "coding", "approved"), {
+      run_status: "active",
+      state: "coding",
+      shown_guides: ["coding"],
+    });
+
+    const snap = s.readSnapshot("shown-append");
+    expect(snap?.shown_guides).toEqual(["coding"]);
   });
 });
 

--- a/packages/freeflow/src/commands/current.ts
+++ b/packages/freeflow/src/commands/current.ts
@@ -2,11 +2,11 @@ import { dirname } from "node:path";
 import { CliError } from "../errors.js";
 import { loadFsm } from "../fsm.js";
 import {
+  buildStateCardForEmit,
   formatStateCard,
   handleError,
   jsonSuccess,
   printJson,
-  stateCardFromFsm,
   substituteCard,
 } from "../output.js";
 import { Store } from "../store.js";
@@ -63,6 +63,28 @@ export function current(args: CurrentArgs): void {
       });
     }
 
+    const { card: rawCard, updatedShownGuides } = buildStateCardForEmit(
+      fsm,
+      snapshot.state,
+      snapshot,
+    );
+
+    // First-time guide emission via `current` must persist the new
+    // shown_guides entry so subsequent reads don't re-show it. Re-read under
+    // the lock to avoid clobbering concurrent writes from other commands.
+    if (updatedShownGuides !== undefined) {
+      store.withLock(args.runId, () => {
+        const latest = store.readSnapshot(args.runId);
+        if (!latest) return;
+        const currentShown = latest.shown_guides ?? [];
+        if (currentShown.includes(snapshot.state)) return;
+        const merged = [...currentShown, snapshot.state];
+        // Commit a no-op event-less snapshot update by re-writing the file
+        // directly via the store's public write path.
+        store.writeSnapshot({ ...latest, shown_guides: merged });
+      });
+    }
+
     const stateSourceDir = fsmState.source_path
       ? dirname(fsmState.source_path)
       : (meta.workflow_dir ?? "");
@@ -71,7 +93,7 @@ export function current(args: CurrentArgs): void {
       workflow_dir: stateSourceDir,
       run_dir: runDir,
     };
-    const card = substituteCard(stateCardFromFsm(snapshot.state, fsmState), vars);
+    const card = substituteCard(rawCard, vars);
 
     const workflowDir = meta.workflow_dir ?? null;
 

--- a/packages/freeflow/src/commands/current.ts
+++ b/packages/freeflow/src/commands/current.ts
@@ -48,44 +48,44 @@ export function current(args: CurrentArgs): void {
       return;
     }
 
-    const snapshot = store.readSnapshot(args.runId);
-    if (!snapshot) {
-      throw new CliError("RUN_NOT_FOUND", "run has no snapshot", {
-        context: { runId: args.runId },
-      });
-    }
     const fsm = loadFsm(meta.fsm_path);
 
-    const fsmState = fsm.states[snapshot.state];
-    if (!fsmState) {
-      throw new CliError("STATE_NOT_FOUND", "state not found in FSM", {
-        context: { runId: args.runId, state: snapshot.state },
-      });
-    }
-
-    const { card: rawCard, updatedShownGuides } = buildStateCardForEmit(
-      fsm,
-      snapshot.state,
-      snapshot,
-    );
-
-    // First-time guide emission via `current` must persist the new
-    // shown_guides entry so subsequent reads don't re-show it. Re-read under
-    // the lock to avoid clobbering concurrent writes from other commands.
-    if (updatedShownGuides !== undefined) {
-      store.withLock(args.runId, () => {
-        const latest = store.readSnapshot(args.runId);
-        if (!latest) return;
+    // Build the state card under the per-run lock so the decision to render
+    // the guide and the shown_guides persist are atomic against concurrent
+    // `goto` commits. Otherwise a concurrent goto could commit
+    // shown_guides=[X] between an unlocked read and the lock, and this call
+    // would still emit a duplicate guide card to the user.
+    let snapshot!: NonNullable<ReturnType<typeof store.readSnapshot>>;
+    let rawCard!: ReturnType<typeof buildStateCardForEmit>["card"];
+    store.withLock(args.runId, () => {
+      const latest = store.readSnapshot(args.runId);
+      if (!latest) {
+        throw new CliError("RUN_NOT_FOUND", "run has no snapshot", {
+          context: { runId: args.runId },
+        });
+      }
+      const fsmState = fsm.states[latest.state];
+      if (!fsmState) {
+        throw new CliError("STATE_NOT_FOUND", "state not found in FSM", {
+          context: { runId: args.runId, state: latest.state },
+        });
+      }
+      const built = buildStateCardForEmit(fsm, latest.state, latest);
+      rawCard = built.card;
+      snapshot = latest;
+      if (built.updatedShownGuides !== undefined) {
         const currentShown = latest.shown_guides ?? [];
-        if (currentShown.includes(snapshot.state)) return;
-        const merged = [...currentShown, snapshot.state];
-        // Commit a no-op event-less snapshot update by re-writing the file
-        // directly via the store's public write path.
-        store.writeSnapshot({ ...latest, shown_guides: merged });
-      });
-    }
+        if (!currentShown.includes(latest.state)) {
+          store.writeSnapshot({
+            ...latest,
+            shown_guides: [...currentShown, latest.state],
+          });
+        }
+      }
+    });
 
-    const stateSourceDir = fsmState.source_path
+    const fsmState = fsm.states[snapshot.state];
+    const stateSourceDir = fsmState?.source_path
       ? dirname(fsmState.source_path)
       : (meta.workflow_dir ?? "");
     const runDir = store.getRunDir(args.runId);

--- a/packages/freeflow/src/commands/goto.ts
+++ b/packages/freeflow/src/commands/goto.ts
@@ -2,6 +2,7 @@ import { dirname } from "node:path";
 import { CliError } from "../errors.js";
 import { loadFsm } from "../fsm.js";
 import {
+  buildStateCardForEmit,
   formatDuration,
   formatLiteCard,
   formatStateCard,
@@ -9,7 +10,6 @@ import {
   handleError,
   jsonSuccess,
   printJson,
-  stateCardFromFsm,
   substituteCard,
 } from "../output.js";
 import { type RunStatus, Store } from "../store.js";
@@ -93,6 +93,14 @@ ${labels}`,
       const isDone = args.target === "done";
       const newStatus: RunStatus = isDone ? "completed" : "active";
 
+      // Build the state card up front so we know whether to append a new
+      // shown_guides entry during the same locked snapshot write.
+      const { card: rawCard, updatedShownGuides } = buildStateCardForEmit(
+        fsm,
+        args.target,
+        snapshot,
+      );
+
       store.commit(
         args.runId,
         {
@@ -107,11 +115,18 @@ ${labels}`,
           run_status: newStatus,
           state: args.target,
           visited_states: visitedStates,
+          ...(updatedShownGuides !== undefined && { shown_guides: updatedShownGuides }),
         },
         { lockHeld: true },
       );
 
-      return { isDone, newStatus, fromState: snapshot.state, alreadyVisited };
+      return {
+        isDone,
+        newStatus,
+        fromState: snapshot.state,
+        alreadyVisited,
+        rawCard,
+      };
     });
 
     const workflowDir = meta.workflow_dir ?? null;
@@ -125,7 +140,7 @@ ${labels}`,
       workflow_dir: stateSourceDir,
       run_dir: runDir,
     };
-    const card = substituteCard(stateCardFromFsm(args.target, fsmState), vars);
+    const card = substituteCard(result.rawCard, vars);
 
     // Compute time spent in previous state
     const events = store.readEvents(args.runId);

--- a/packages/freeflow/src/commands/start.ts
+++ b/packages/freeflow/src/commands/start.ts
@@ -4,13 +4,13 @@ import { CliError } from "../errors.js";
 import { type Fsm, loadFsm } from "../fsm.js";
 import { serializeMarkdown } from "../markdown-serializer.js";
 import {
+  buildStateCardForEmit,
   formatStateCard,
   formatSubagentDispatch,
   fsmToMermaid,
   handleError,
   jsonSuccess,
   printJson,
-  stateCardFromFsm,
   substituteCard,
   substituteVars,
 } from "../output.js";
@@ -98,6 +98,21 @@ ${markdown}
       return;
     }
 
+    // Build the state card first so we know whether to record a new
+    // shown_guides entry as part of this snapshot write.
+    const emptySnapshot = {
+      run_id: runId,
+      run_status: "active" as const,
+      state: fsm.initial,
+      last_seq: 0,
+      updated_at: "",
+    };
+    const { card: rawCard, updatedShownGuides } = buildStateCardForEmit(
+      fsm,
+      fsm.initial,
+      emptySnapshot,
+    );
+
     store.commit(
       runId,
       {
@@ -112,6 +127,7 @@ ${markdown}
         run_status: "active",
         state: fsm.initial,
         ...(args.lite && { visited_states: [fsm.initial] }),
+        ...(updatedShownGuides !== undefined && { shown_guides: updatedShownGuides }),
       },
     );
 
@@ -121,10 +137,7 @@ ${markdown}
       workflow_dir: stateSourceDir,
       run_dir: runDir,
     };
-    const card = substituteCard(
-      stateCardFromFsm(fsm.initial, fsm.states[fsm.initial]),
-      vars,
-    );
+    const card = substituteCard(rawCard, vars);
 
     const mermaid = fsmToMermaid(fsm.states, fsm.initial);
 

--- a/packages/freeflow/src/fsm.ts
+++ b/packages/freeflow/src/fsm.ts
@@ -352,8 +352,8 @@ function resolveWorkflowStates(
         expandedState.transitions = rewrittenTransitions;
       }
 
-      // Apply child guide as per-state guide override
-      if (childFsm.guide) {
+      // Apply child guide only to the expanded child initial state
+      if (childFsm.guide && childStateName === childFsm.initial) {
         expandedState.guide = childFsm.guide;
       }
 

--- a/packages/freeflow/src/output.ts
+++ b/packages/freeflow/src/output.ts
@@ -1,8 +1,9 @@
 import { Marked } from "marked";
 import { markedTerminal } from "marked-terminal";
 import { CliError } from "./errors.js";
-import type { FsmState } from "./fsm.js";
+import type { Fsm, FsmState } from "./fsm.js";
 import { FsmError } from "./fsm.js";
+import type { Snapshot } from "./store.js";
 
 // --- Variable Substitution ---
 
@@ -49,11 +50,51 @@ export function stateCardFromFsm(stateName: string, fsmState: FsmState): StateCa
   return card;
 }
 
+/**
+ * Build a state card for emission by `fflow start`, `fflow goto`, and
+ * `fflow current`, gating per-state `guide` emission on
+ * `snapshot.shown_guides`.
+ *
+ * - First emission of a state with a `guide` keeps the guide on the card and
+ *   returns an `updatedShownGuides` array (existing entries plus `stateName`)
+ *   that the caller must persist to the snapshot.
+ * - Subsequent emissions for the same state strip the `guide` from the card
+ *   and omit `updatedShownGuides` (no snapshot write required).
+ * - States without a `guide` pass through unchanged.
+ *
+ * The subagent dispatch path (`formatSubagentDispatch`) is the bypass: it
+ * always surfaces the per-state guide because subagents run in separate
+ * contexts and are expected to see the guide every time.
+ */
+export function buildStateCardForEmit(
+  fsm: Fsm,
+  stateName: string,
+  snapshot: Snapshot,
+): { card: StateCard; updatedShownGuides?: string[] } {
+  const fsmState = fsm.states[stateName];
+  const card = stateCardFromFsm(stateName, fsmState);
+  const shown = snapshot.shown_guides ?? [];
+
+  if (card.guide === undefined) {
+    return { card };
+  }
+  if (shown.includes(stateName)) {
+    const { guide: _stripped, ...rest } = card;
+    return { card: rest };
+  }
+  return { card, updatedShownGuides: [...shown, stateName] };
+}
+
 const TODO_HEADER =
   "You MUST create a task for each of these items and complete them in order:";
 
 export function formatStateCard(card: StateCard): string {
   const lines: string[] = [];
+
+  if (card.guide) {
+    lines.push(card.guide);
+    lines.push("");
+  }
 
   lines.push(`You are in **${card.state}** state.`);
   lines.push("");

--- a/packages/freeflow/src/store.ts
+++ b/packages/freeflow/src/store.ts
@@ -218,6 +218,21 @@ export class Store {
     return JSON.parse(raw) as Snapshot;
   }
 
+  /**
+   * Overwrite a run's snapshot file with the given `Snapshot`. Event-less —
+   * does not append to the event log or bump `last_seq`. Intended for the
+   * narrow case where runtime tracking fields (e.g. `shown_guides`) need to
+   * be persisted without a user-visible state change. Callers must hold the
+   * lock (via `withLock`) if they need exclusion against concurrent writers.
+   */
+  writeSnapshot(snapshot: Snapshot): void {
+    writeFileSync(
+      this.snapshotPath(snapshot.run_id),
+      JSON.stringify(snapshot, null, 2),
+      "utf-8",
+    );
+  }
+
   readEvents(runId: string): StoreEvent[] {
     const p = this.eventsPath(runId);
     if (!existsSync(p)) {

--- a/packages/freeflow/src/store.ts
+++ b/packages/freeflow/src/store.ts
@@ -56,6 +56,7 @@ export interface Snapshot {
   last_seq: number;
   updated_at: string;
   visited_states?: string[];
+  shown_guides?: string[];
 }
 
 export interface EventInput {
@@ -72,6 +73,7 @@ export interface SnapshotInput {
   run_status: RunStatus;
   state: string;
   visited_states?: string[];
+  shown_guides?: string[];
 }
 
 // --- Helpers ---
@@ -278,6 +280,8 @@ export class Store {
 
       // Resolve visited_states: use input if provided, else carry forward from current snapshot
       const visitedStates = snapshotInput.visited_states ?? currentSnap?.visited_states;
+      // Resolve shown_guides: use input if provided, else carry forward from current snapshot
+      const shownGuides = snapshotInput.shown_guides ?? currentSnap?.shown_guides;
 
       // Write snapshot
       const snapshot: Snapshot = {
@@ -287,6 +291,7 @@ export class Store {
         last_seq: event.seq,
         updated_at: now,
         ...(visitedStates !== undefined && { visited_states: visitedStates }),
+        ...(shownGuides !== undefined && { shown_guides: shownGuides }),
       };
       writeFileSync(
         this.snapshotPath(runId),


### PR DESCRIPTION
## Summary

- Attach a child workflow's top-level `guide:` only to its expanded **initial** state (not every expanded state) — previously the guide leaked onto every sub-state of the embedded workflow.
- Persist a `shown_guides: string[]` list on the runtime snapshot so the state card can dedupe guide emission to the first visit of the initial state.
- Gate guide rendering in `fflow start` / `goto` / `current` on `shown_guides`, making the parent agent see the sub-workflow guide exactly once — on first entry to the sub-workflow's initial state.
- Make the decision to render the guide and the `shown_guides` persist atomic under the per-run lock in `current` (race fix).

Extracted from the larger workflow-inheritance refactor (#146) so this self-contained behavioral fix can land on its own.

## Test plan

- [x] `npm run build -w packages/freeflow`
- [x] `npm test -w packages/freeflow` — 240 tests pass (includes new T11 + `guide-gating.test.ts`)
- [x] `npm run check` — biome clean
- [ ] Smoke run: `fflow start` a parent workflow that embeds a child with a guide, verify the child guide appears on first entry to the child initial state only