### PR TITLE
feat(freeflow): remove Codex install backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,6 @@ jobs:
           cache: 'npm'
       - name: Install Claude Code
         run: curl -fsSL https://claude.ai/install.sh | bash
-      - name: Install Codex
-        run: npm install -g @openai/codex
       - run: npm ci
       - run: npm run build
       - run: npm run test:integration

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -52,7 +52,7 @@ jobs:
         run: curl -fsSL https://claude.ai/install.sh | bash
 
       - name: Install freeflow plugin
-        run: fflow install claude
+        run: fflow install
 
       - name: Run code review
         timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Monorepo for FreeMatters — agent-native developer tools.
 
 ```bash
 npm install -g @freematters/freeflow
-fflow install claude    # or: fflow install codex
+fflow install
 ```
 
 See [packages/freeflow/README.md](packages/freeflow/README.md) for full documentation.

--- a/packages/freeflow/README.md
+++ b/packages/freeflow/README.md
@@ -2,7 +2,7 @@
 
 CLI-first workflow runtime for agent workflows. Define states and transitions in YAML; the CLI enforces valid paths while leaving in-state reasoning to the LLM.
 
-Works with **Claude Code** and **Codex**.
+Works with **Claude Code**.
 
 ## Why
 
@@ -26,15 +26,11 @@ Or install manually:
 ```bash
 npm install -g @freematters/freeflow
 
-# Claude Code — registers the PostToolUse hook + installs skills and workflows
-fflow install claude
-
-# Codex — installs skills and workflows (no hook support)
-fflow install codex
+fflow install
 ```
 
-Both commands register the bundled skills and workflows into the agent's skill
-directories.
+This registers the bundled skills and workflows into Claude Code, along with
+the PostToolUse hook.
 
 ### For Contributors
 
@@ -44,7 +40,7 @@ cd freematters
 npm install && npm run build
 npm link -w packages/freeflow
 
-fflow install claude
+fflow install
 ```
 
 ## Usage
@@ -54,8 +50,6 @@ FreeFlow is typically used through these skills:
 - `/fflow-author` — guided Q&A to create or edit a workflow YAML
 - `/fflow <path>` — start a workflow run (also searches `./workflows/` by name)
 - `/fflow:e2e-run` — run e2e agent tests
-
-Codex skill names use `$` instead of `/`.
 
 ## Bundled Workflows
 

--- a/packages/freeflow/scripts/reinstall.sh
+++ b/packages/freeflow/scripts/reinstall.sh
@@ -8,4 +8,4 @@ npm run build
 npm install -g .
 
 # Register as Claude plugin
-fflow install claude
+fflow install

--- a/packages/freeflow/src/__tests__/install.test.ts
+++ b/packages/freeflow/src/__tests__/install.test.ts
@@ -16,9 +16,9 @@ const PACKAGE_ROOT = resolve(__dirname, "../..");
 const SKILLS_DIR = join(PACKAGE_ROOT, "skills");
 const WORKFLOWS_DIR = join(PACKAGE_ROOT, "workflows");
 
-// ─── Install: claude backend ────────────────────────────────────
+// ─── Install ────────────────────────────────────────────────────
 
-describe("install claude (with stubbed execFileSync)", () => {
+describe("install (with stubbed execFileSync)", () => {
   beforeEach(() => {
     execFileSyncMock.mockReset();
     execFileSyncMock.mockImplementation(() => Buffer.from(""));

--- a/packages/freeflow/src/__tests__/install.test.ts
+++ b/packages/freeflow/src/__tests__/install.test.ts
@@ -2,22 +2,13 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-const { execFileSyncMock, symlinkSyncMock } = vi.hoisted(() => ({
+const { execFileSyncMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
-  symlinkSyncMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
   execFileSync: execFileSyncMock,
 }));
-
-vi.mock("node:fs", async () => {
-  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-  return {
-    ...actual,
-    symlinkSync: symlinkSyncMock,
-  };
-});
 
 const { install } = await import("../commands/install.js");
 
@@ -38,7 +29,7 @@ describe("install claude (with stubbed execFileSync)", () => {
   });
 
   test("plugin install is invoked, then npx skills install twice (in order)", () => {
-    install("claude");
+    install();
 
     const calls = execFileSyncMock.mock.calls;
 
@@ -80,7 +71,7 @@ describe("install claude (with stubbed execFileSync)", () => {
       return Buffer.from("");
     });
 
-    expect(() => install("claude")).toThrow();
+    expect(() => install()).toThrow();
 
     const calls = execFileSyncMock.mock.calls;
     const uninstallCall = calls.find(
@@ -92,58 +83,6 @@ describe("install claude (with stubbed execFileSync)", () => {
         c[1][2] === "freeflow@freeflow-local",
     );
     expect(uninstallCall).toBeDefined();
-  });
-});
-
-// ─── Install: codex backend ─────────────────────────────────────
-
-describe("install codex (with stubbed execFileSync)", () => {
-  beforeEach(() => {
-    execFileSyncMock.mockReset();
-    execFileSyncMock.mockImplementation(() => Buffer.from(""));
-  });
-
-  afterEach(() => {
-    execFileSyncMock.mockReset();
-  });
-
-  test("no symlink is created at ~/.agents/skills/freeflow and npx skills install is invoked twice", () => {
-    symlinkSyncMock.mockReset();
-
-    install("codex");
-
-    expect(symlinkSyncMock).not.toHaveBeenCalled();
-
-    const npxCalls = execFileSyncMock.mock.calls.filter(
-      (c) =>
-        c[0] === "npx" &&
-        Array.isArray(c[1]) &&
-        c[1][0] === "skills" &&
-        c[1][1] === "install",
-    );
-    expect(npxCalls).toHaveLength(2);
-    expect(npxCalls[0][1]).toEqual(["skills", "install", SKILLS_DIR]);
-    expect(npxCalls[1][1]).toEqual(["skills", "install", WORKFLOWS_DIR]);
-  });
-
-  test("on npx skills install failure, exits non-zero and no plugin rollback is attempted", () => {
-    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "npx" && args[0] === "skills" && args[1] === "install") {
-        throw new Error("npx skills install failed");
-      }
-      return Buffer.from("");
-    });
-
-    expect(() => install("codex")).toThrow();
-
-    const uninstallCall = execFileSyncMock.mock.calls.find(
-      (c) =>
-        c[0] === "claude" &&
-        Array.isArray(c[1]) &&
-        c[1][0] === "plugin" &&
-        c[1][1] === "uninstall",
-    );
-    expect(uninstallCall).toBeUndefined();
   });
 });
 

--- a/packages/freeflow/src/cli.ts
+++ b/packages/freeflow/src/cli.ts
@@ -241,14 +241,9 @@ program
 
 program
   .command("install")
-  .description("register freeflow with an agent platform")
-  .argument("<platform>", "target platform: claude or codex")
-  .action((platform: string) => {
-    if (platform !== "claude" && platform !== "codex") {
-      console.error(`Unknown platform "${platform}". Use "claude" or "codex".`);
-      process.exit(2);
-    }
-    install(platform as "claude" | "codex");
+  .description("register freeflow with Claude Code")
+  .action(() => {
+    install();
   });
 
 program

--- a/packages/freeflow/src/commands/install.ts
+++ b/packages/freeflow/src/commands/install.ts
@@ -19,7 +19,7 @@ function run(cmd: string, args: string[]): void {
   execFileSync(cmd, args, { stdio: "inherit" });
 }
 
-function runNpxSkills(packageRoot: string, onFailure?: () => void): void {
+function runNpxSkills(packageRoot: string, onFailure: () => void): void {
   const dirs = [join(packageRoot, "skills"), join(packageRoot, "workflows")];
   try {
     for (const dir of dirs) {
@@ -27,7 +27,7 @@ function runNpxSkills(packageRoot: string, onFailure?: () => void): void {
       run("npx", ["skills", "install", dir]);
     }
   } catch (err) {
-    onFailure?.();
+    onFailure();
     throw err;
   }
 }

--- a/packages/freeflow/src/commands/install.ts
+++ b/packages/freeflow/src/commands/install.ts
@@ -1,8 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 
-type Platform = "claude" | "codex";
-
 const MARKETPLACE_NAME = "freeflow-local";
 const PLUGIN_NAME = "freeflow";
 
@@ -12,14 +10,9 @@ function getPackageRoot(): string {
   return resolve(thisDir, "..", "..");
 }
 
-export function install(platform: Platform): void {
+export function install(): void {
   const packageRoot = getPackageRoot();
-
-  if (platform === "claude") {
-    installClaude(packageRoot);
-  } else {
-    installCodex(packageRoot);
-  }
+  installClaude(packageRoot);
 }
 
 function run(cmd: string, args: string[]): void {
@@ -69,13 +62,4 @@ function installClaude(packageRoot: string): void {
   console.log("\nSkills: /fflow-author, /fflow, /e2e-run");
   console.log("Hook: PostToolUse state reminder (every 5 tool calls)");
   console.log("\nRestart Claude Code to activate the plugin.");
-}
-
-function installCodex(packageRoot: string): void {
-  runNpxSkills(packageRoot);
-
-  console.log("\nFreeFlow skills installed for Codex.");
-  console.log(
-    `\nNote: Codex does not support hooks. The agent won't get periodic state reminders.`,
-  );
 }


### PR DESCRIPTION
## Summary

Removes the Codex install backend. `fflow install` now only supports Claude Code and takes no platform argument.

## Changes

- `fflow install` no longer takes a `<platform>` argument (previously `claude` | `codex`)
- Drop `installCodex` code path in `src/commands/install.ts`
- Drop Codex install step from CI workflow (`npm install -g @openai/codex`)
- Update README usage docs to reflect single-target install
- Remove Codex-specific tests in `install.test.ts`; rename remaining test suite

## Test plan

- [x] `npm run check` passes
- [x] `install.test.ts` covers the new `install()` signature (no-arg)
- [x] `npm test` passes on CI

## Push round 1
- Update `.github/workflows/code-review.yml` to call `fflow install` (no arg) — the previous `fflow install claude` broke the review job because the CLI no longer accepts a platform positional
- Update `packages/freeflow/scripts/reinstall.sh` for the same reason