### PR TITLE
feat(freeflow): scope install-workflow -y to claude-code + codex

### DIFF
--- a/packages/freeflow/README.md
+++ b/packages/freeflow/README.md
@@ -30,7 +30,7 @@ the workflow templates you'll actually run.
 # 1. Install the FreeFlow plugin into Claude Code (skills + hooks bundled)
 npx fflow init
 
-# 2. Install workflow templates (every workflow + every agent pre-selected)
+# 2. Install workflow templates (pick workflows + agents interactively)
 npx fflow install-workflow [--local | --global] [-y]
 ```
 
@@ -39,12 +39,12 @@ and also lays down the same skills globally for Codex via
 `npx skills add -g --agent codex`. **Restart Claude Code** afterwards so the
 PostToolUse hook activates.
 
-`install-workflow` shells out to `npx skills add` with every workflow and
-every agent pre-selected (`--skill '*' --agent '*'`); the skills CLI still
-shows its confirmation picker so you can review what will be installed. Pass
-`-y` to skip the confirmation for non-interactive runs. Use `--local` to
-install workflows into the current repo (default in `-y` mode) or `--global`
-to make them available everywhere.
+`install-workflow` shells out to `npx skills add` and lets the skills CLI
+prompt you to pick which workflows and which agents to install. Pass `-y` to
+skip the prompts and install every workflow into both claude-code and codex
+(`--skill '*' --agent claude-code codex -y`) — handy for CI or scripts. Use
+`--local` to install workflows into the current repo (default in `-y` mode)
+or `--global` to make them available everywhere.
 
 ### Your first workflow
 

--- a/packages/freeflow/src/__tests__/install-workflow.test.ts
+++ b/packages/freeflow/src/__tests__/install-workflow.test.ts
@@ -52,7 +52,7 @@ describe("runInstallWorkflow", () => {
     });
   });
 
-  test("--local pre-selects every skill and every agent; confirmation picker still shows", async () => {
+  test("--local lets the skills CLI prompt for workflow + agent selection", async () => {
     await runInstallWorkflow({ scope: "local" });
 
     const call = findSkillsAddCall();
@@ -62,29 +62,27 @@ describe("runInstallWorkflow", () => {
     // target dir is the bundled workflows/
     expect(args[3]).toBe(WORKFLOWS_DIR);
 
-    // skill + agent are pre-selected
-    expect(args.slice(4)).toContain("--skill");
-    expect(args[args.indexOf("--skill") + 1]).toBe("*");
-    expect(args).toContain("--agent");
-    expect(args[args.indexOf("--agent") + 1]).toBe("*");
+    // no --skill / --agent → skills CLI runs its own interactive pickers
+    expect(args).not.toContain("--skill");
+    expect(args).not.toContain("--agent");
 
-    // no -y → skills CLI still shows its confirmation picker
+    // no -y → skills CLI confirmation stays live
     expect(args).not.toContain("-y");
 
     // local scope → no -g
     expect(args).not.toContain("-g");
   });
 
-  test("--global adds -g and keeps the pre-selection", async () => {
+  test("--global adds -g and keeps the interactive pickers", async () => {
     await runInstallWorkflow({ scope: "global" });
 
     const args = findSkillsAddCall()?.[1] as string[];
-    expect(args).toContain("--skill");
-    expect(args).toContain("--agent");
+    expect(args).not.toContain("--skill");
+    expect(args).not.toContain("--agent");
     expect(args).toContain("-g");
   });
 
-  test("-y skips the scope prompt and the skills CLI confirmation", async () => {
+  test("-y installs every workflow for claude-code + codex and skips prompts", async () => {
     await runInstallWorkflow({ yes: true });
 
     expect(promptsMock).not.toHaveBeenCalled();
@@ -92,8 +90,10 @@ describe("runInstallWorkflow", () => {
     const args = findSkillsAddCall()?.[1] as string[];
     expect(args).toContain("--skill");
     expect(args[args.indexOf("--skill") + 1]).toBe("*");
-    expect(args).toContain("--agent");
-    expect(args[args.indexOf("--agent") + 1]).toBe("*");
+    const agentIdx = args.indexOf("--agent");
+    expect(agentIdx).toBeGreaterThanOrEqual(0);
+    expect(args[agentIdx + 1]).toBe("claude-code");
+    expect(args[agentIdx + 2]).toBe("codex");
     expect(args).toContain("-y");
     // default scope under -y is local
     expect(args).not.toContain("-g");

--- a/packages/freeflow/src/__tests__/runners.test.ts
+++ b/packages/freeflow/src/__tests__/runners.test.ts
@@ -17,8 +17,12 @@ describe("runners", () => {
     execFileSyncMock.mockImplementation(() => Buffer.from(""));
   });
 
-  test("skillsAdd all: true pre-fills --skill '*' --agent '*' and honors yes for -y", () => {
-    skillsAdd("/some/dir", { scope: "global", all: true, yes: true });
+  test("skillsAdd non-interactive with multiple agents emits --skill '*' --agent a b and -y", () => {
+    skillsAdd("/some/dir", {
+      scope: "global",
+      agents: ["claude-code", "codex"],
+      yes: true,
+    });
 
     const [, args] = execFileSyncMock.mock.calls[0];
     expect(args).toEqual([
@@ -29,19 +33,30 @@ describe("runners", () => {
       "--skill",
       "*",
       "--agent",
-      "*",
+      "claude-code",
+      "codex",
       "-y",
       "-g",
     ]);
   });
 
+  test("skillsAdd interactive omits --skill and --agent so the skills CLI prompts", () => {
+    skillsAdd("/some/dir", { scope: "local", interactive: true });
+
+    const [, args] = execFileSyncMock.mock.calls[0];
+    expect(args).not.toContain("--skill");
+    expect(args).not.toContain("--agent");
+    expect(args).not.toContain("-y");
+    expect(args).not.toContain("-g");
+  });
+
   test("skillsAdd quiet pipes stdio; default inherits", () => {
-    skillsAdd("/a", { scope: "local", all: true, yes: true, quiet: true });
+    skillsAdd("/a", { scope: "local", agents: ["codex"], yes: true, quiet: true });
     const quietStdio = (execFileSyncMock.mock.calls[0][2] as { stdio?: string }).stdio;
     expect(quietStdio).toBe("pipe");
 
     execFileSyncMock.mockReset();
-    skillsAdd("/a", { scope: "local", all: true, yes: true });
+    skillsAdd("/a", { scope: "local", agents: ["codex"], yes: true });
     const defaultStdio = (execFileSyncMock.mock.calls[0][2] as { stdio?: string })
       .stdio;
     expect(defaultStdio).toBe("inherit");

--- a/packages/freeflow/src/cli.ts
+++ b/packages/freeflow/src/cli.ts
@@ -263,11 +263,14 @@ program
 program
   .command("install-workflow")
   .description(
-    "install FreeFlow workflows (all skills + all agents pre-selected; -y to skip confirmation)",
+    "install FreeFlow workflows (interactively pick workflows + agents; -y installs everything for claude-code + codex)",
   )
   .option("--local", "install at project scope")
   .option("--global", "install at user scope")
-  .option("-y, --yes", "skip all interactive prompts (defaults: local scope)")
+  .option(
+    "-y, --yes",
+    "skip prompts and install every workflow for claude-code + codex (default scope: local)",
+  )
   .action(async (opts: Record<string, unknown>, cmd: Command) => {
     const { json } = getGlobalOpts(cmd);
     try {

--- a/packages/freeflow/src/commands/init.ts
+++ b/packages/freeflow/src/commands/init.ts
@@ -40,8 +40,9 @@ export async function runInit(opts: InitOptions = {}): Promise<void> {
   console.log("Installing Codex skills globally…");
   skillsAdd(join(packageRoot, "skills"), {
     scope: "global",
-    agent: "codex",
+    agents: ["codex"],
     interactive: false,
+    yes: true,
     quiet: true,
   });
   console.log("✓ Codex skills installed");

--- a/packages/freeflow/src/commands/install-workflow.ts
+++ b/packages/freeflow/src/commands/install-workflow.ts
@@ -44,12 +44,13 @@ async function resolveScope(opts: InstallWorkflowOptions): Promise<Scope> {
 export async function runInstallWorkflow(opts: InstallWorkflowOptions): Promise<void> {
   const scope = await resolveScope(opts);
 
-  // Pre-select every workflow and every agent (`--skill '*' --agent '*'`).
-  // The skills CLI still renders its confirmation picker so the user can
-  // see what's about to land; `-y` skips it for non-interactive runs.
+  // Default: let the skills CLI prompt for both workflow and agent
+  // selection. `-y` short-circuits the prompts and installs every workflow
+  // for both claude-code and codex — handy for CI and scripts.
   skillsAdd(join(getPackageRoot(), "workflows"), {
     scope,
-    all: true,
+    interactive: opts.yes !== true,
+    agents: opts.yes === true ? ["claude-code", "codex"] : undefined,
     yes: opts.yes,
   });
 

--- a/packages/freeflow/src/runners.ts
+++ b/packages/freeflow/src/runners.ts
@@ -6,21 +6,18 @@ export type Scope = "local" | "global";
 
 export interface SkillsAddOptions {
   scope: Scope;
-  agent?: string;
+  /**
+   * Agents to install into (e.g., `["claude-code", "codex"]`). When omitted,
+   * no `--agent` flag is passed — combine with `interactive: true` to let
+   * the skills CLI prompt for agent selection.
+   */
+  agents?: readonly string[];
   /**
    * When true, let the `skills` CLI drive its own interactive prompts
-   * (skill picker, agent picker) by omitting `--skill '*'` and `-y`.
-   * When false (default), install every skill non-interactively.
+   * (skill picker, agent picker) by omitting `--skill '*'`.
+   * When false (default), install every skill via `--skill '*'`.
    */
   interactive?: boolean;
-  /**
-   * When true, pre-select every skill and every agent (`--skill '*'
-   * --agent '*'`) so the skills CLI still shows its confirmation prompt
-   * but doesn't ask the user to pick individual skills or agents.
-   * Combine with `yes: true` for a fully non-interactive `--all`-like
-   * install. Overrides `agent` and `interactive`.
-   */
-  all?: boolean;
   /** Append `-y` to skip the skills CLI's confirmation prompt. */
   yes?: boolean;
   /**
@@ -75,18 +72,14 @@ function runMaybeQuiet(cmd: string, argv: string[], quiet: boolean): void {
 
 export function skillsAdd(dir: string, opts: SkillsAddOptions): void {
   const argv: string[] = ["--yes", "skills", "add", dir];
-  if (opts.all) {
-    argv.push("--skill", "*", "--agent", "*");
-    if (opts.yes) {
-      argv.push("-y");
-    }
-  } else {
-    if (!opts.interactive) {
-      argv.push("--skill", "*", "-y");
-    }
-    if (opts.agent) {
-      argv.push("--agent", opts.agent);
-    }
+  if (!opts.interactive) {
+    argv.push("--skill", "*");
+  }
+  if (opts.agents && opts.agents.length > 0) {
+    argv.push("--agent", ...opts.agents);
+  }
+  if (opts.yes) {
+    argv.push("-y");
   }
   if (opts.scope === "global") {
     argv.push("-g");


### PR DESCRIPTION
## Summary

- `fflow install-workflow -y` previously installed workflows into **every agent** the `skills` CLI knows about (`--skill '*' --agent '*' -y`). It now installs every workflow into **claude-code and codex only** (`--skill '*' --agent claude-code codex -y`).
- The default (no `-y`) path is unchanged: the `skills` CLI still drives its own interactive workflow and agent pickers.
- `SkillsAddOptions.all` is removed; `agent?: string` is replaced with `agents?: readonly string[]`. `init.ts` updated to pass `agents: ["codex"]` + explicit `yes: true`.

## Test plan

- [x] `npm test` in `packages/freeflow` — 177/177 passing
- [x] `npm run check` — biome clean
- [ ] Manual: `npx fflow install-workflow -y` installs into claude-code and codex only
- [ ] Manual: `npx fflow install-workflow` still shows interactive pickers