### PR TITLE
fix(tests): normalize temp paths and skip frontend test when not built

### DIFF
--- a/packages/codoc/src/__tests__/websocket.test.ts
+++ b/packages/codoc/src/__tests__/websocket.test.ts
@@ -254,6 +254,8 @@ describe("HTTP SPA serving", () => {
   });
 
   it("GET /edit/:token should serve index.html from dist/static/ if it exists", async () => {
+    const indexPath = path.join(__dirname, "..", "..", "dist", "static", "index.html");
+    if (!fs.existsSync(indexPath)) return;
     const reg = tokenStore.register(testFilePath, false);
     const res = await new Promise<{ statusCode: number; body: string }>(
       (resolve, reject) => {

--- a/packages/freeflow/src/__tests__/fixtures.ts
+++ b/packages/freeflow/src/__tests__/fixtures.ts
@@ -5,7 +5,7 @@
  * and event builders used across multiple test files.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { EventInput, SnapshotInput } from "../store.js";
@@ -102,7 +102,7 @@ export function uniqueRunId(prefix = "run"): string {
 // ─── Temp Directory Helpers ──────────────────────────────────────
 
 export function createTempDir(prefix: string): string {
-  return mkdtempSync(join(tmpdir(), `freeflow-${prefix}-`));
+  return realpathSync(mkdtempSync(join(tmpdir(), `freeflow-${prefix}-`)));
 }
 
 export function cleanupTempDir(path: string): void {


### PR DESCRIPTION
- Use realpathSync in createTempDir so expected paths match macOS symlink resolution (/var → /private/var) in resolve-workflow tests
- Skip the SPA index.html test in codoc when dist/static/ hasn't been built, matching the conditional intent of the test title